### PR TITLE
v0.3.0 -> v0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name            = "simple-concurrent-get"
-version         = "0.3.0"
+version         = "0.3.1"
 edition         = "2021"
 license         = "GPL-3.0"
 authors         = ["ParkSnoopy <sunwoo2539@gmail.com>"]
@@ -12,11 +12,11 @@ categories      = ["network-programming", "web-programming", "concurrency"]
 keywords        = ["concurrent", "http", "get", "request"]
 
 [dependencies]
-reqwest = "0.12.9"
+reqwest = { version = "0.12.9", features = ["deflate", "gzip"] }
 futures-util = "0.3.31"
-futures-executor = "0.3.31"
 
 [dev-dependencies]
+tokio = { version = "1.41.1", features = ["macros", "rt-multi-thread"] }
+futures-executor = "0.3.31"
 itertools = "0.13.0"
 scraper = "0.21.0"
-tokio = { version = "1.41.1", features = ["macros", "rt-multi-thread"] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,0 +1,14 @@
+use reqwest::Client;
+
+use crate::config;
+
+
+
+pub fn build_preset() -> Client {
+    Client::builder()
+        .user_agent(config::USER_AGENT)
+        .gzip(true)
+        .deflate(true)
+        .build()
+        .unwrap()
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,1 +1,2 @@
-pub const USER_AGENT: &str = "simple-concurrent-get/0.3";
+//pub const USER_AGENT: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:132.0) Gecko/20100101 Firefox/132.0";
+pub const USER_AGENT: &str = "simple-concurrent-get/0.3.1";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@
 
 
 mod config;
+mod client;
 
 pub mod unordered;
 pub mod ordered;

--- a/src/ordered/get.rs
+++ b/src/ordered/get.rs
@@ -8,7 +8,7 @@ use std::sync::mpsc::{
 };
 
 use crate::{
-    config,
+    client,
 };
 
 
@@ -18,10 +18,7 @@ where
     I: IntoIterator<Item=S>,
     S: reqwest::IntoUrl,
 {
-    let client: Arc<Client> = Arc::new(Client::builder()
-        .user_agent(config::USER_AGENT)
-        .build()
-        .unwrap());
+    let client: Arc<Client> = Arc::new(client::build_preset());
 
     let (sender, receiver) = channel();
 
@@ -43,5 +40,6 @@ where
         })
         .await;
 
+    drop(sender);
     receiver.into_iter()
 }

--- a/src/ordered/get_foreach.rs
+++ b/src/ordered/get_foreach.rs
@@ -7,7 +7,9 @@ use std::sync::mpsc::{
     channel,
 };
 
-use crate::config;
+use crate::{
+    client,
+};
 
 
 
@@ -17,10 +19,7 @@ where
     I: IntoIterator<Item=S>,
     F: Copy + FnOnce(reqwest::Result<Response>) -> R,
 {
-    let client: Arc<Client> = Arc::new(Client::builder()
-        .user_agent(config::USER_AGENT)
-        .build()
-        .unwrap());
+    let client: Arc<Client> = Arc::new(client::build_preset());
 
     let (sender, receiver) = channel();
 
@@ -44,5 +43,6 @@ where
         })
         .await;
 
+    drop(sender);
     receiver.into_iter()
 }

--- a/src/tests/ordered.rs
+++ b/src/tests/ordered.rs
@@ -8,18 +8,25 @@ use crate::ordered::{
     concurrent_get_foreach,
 };
 
-const TO_FETCH: &[&str; 5] = &[
+const TO_FETCH: &[&str; 11] = &[
     "Amarr:Jita:Dodixie:Hek:Rens:Nisuwa",
     "Jita:Dodixie:Hek:Rens:Nisuwa",
     "Amarr:Dodixie:Hek:Rens:Nisuwa",
     "Amarr:Jita:Hek:Rens:Nisuwa",
     "Amarr:Jita:Dodixie:Rens:Nisuwa",
+
+    "Covryn:Brarel:Frarie:Renarelle:Vivanier",
+    "Covryn:Brarel:Frarie:Renarelle:Nisuwa",
+    "Covryn:Brarel:Frarie:Vivanier:Nisuwa",
+    "Covryn:Brarel:Renarelle:Vivanier:Nisuwa",
+    "Covryn:Frarie:Renarelle:Vivanier:Nisuwa",
+    "Brarel:Frarie:Renarelle:Vivanier:Nisuwa",
 ];
-const CONCURRENT: usize = 3;
+const CONCURRENT: usize = 2;
 
 
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_ordered_concurrent_get() {
     let fetch_urls_iter = TO_FETCH
         .iter()
@@ -38,18 +45,26 @@ async fn test_ordered_concurrent_get() {
         })
         .collect();
 
-    assert_eq!(results,
+    assert_eq!(
+        results,
         vec![
-            ( 106, "https://evemaps.dotlan.net/route/3:Amarr:Jita:Dodixie:Hek:Rens:Nisuwa".to_string() ),
-            (  66, "https://evemaps.dotlan.net/route/3:Jita:Dodixie:Hek:Rens:Nisuwa"      .to_string() ),
-            (  86, "https://evemaps.dotlan.net/route/3:Amarr:Dodixie:Hek:Rens:Nisuwa"     .to_string() ),
-            (  79, "https://evemaps.dotlan.net/route/3:Amarr:Jita:Hek:Rens:Nisuwa"        .to_string() ),
-            (  98, "https://evemaps.dotlan.net/route/3:Amarr:Jita:Dodixie:Rens:Nisuwa"    .to_string() ),
+            (106, "https://evemaps.dotlan.net/route/3:Amarr:Jita:Dodixie:Hek:Rens:Nisuwa"      .to_string() ),
+            (66 , "https://evemaps.dotlan.net/route/3:Jita:Dodixie:Hek:Rens:Nisuwa"            .to_string() ),
+            (86 , "https://evemaps.dotlan.net/route/3:Amarr:Dodixie:Hek:Rens:Nisuwa"           .to_string() ),
+            (79 , "https://evemaps.dotlan.net/route/3:Amarr:Jita:Hek:Rens:Nisuwa"              .to_string() ),
+            (98 , "https://evemaps.dotlan.net/route/3:Amarr:Jita:Dodixie:Rens:Nisuwa"          .to_string() ),
+
+            (20 , "https://evemaps.dotlan.net/route/3:Covryn:Brarel:Frarie:Renarelle:Vivanier" .to_string() ),
+            (19 , "https://evemaps.dotlan.net/route/3:Covryn:Brarel:Frarie:Renarelle:Nisuwa"   .to_string() ),
+            (29 , "https://evemaps.dotlan.net/route/3:Covryn:Brarel:Frarie:Vivanier:Nisuwa"    .to_string() ),
+            (33 , "https://evemaps.dotlan.net/route/3:Covryn:Brarel:Renarelle:Vivanier:Nisuwa" .to_string() ),
+            (29 , "https://evemaps.dotlan.net/route/3:Covryn:Frarie:Renarelle:Vivanier:Nisuwa" .to_string() ),
+            (27 , "https://evemaps.dotlan.net/route/3:Brarel:Frarie:Renarelle:Vivanier:Nisuwa" .to_string() ),
         ]
     );
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_ordered_concurrent_get_foreach() {
     let fetch_urls_iter = TO_FETCH
         .iter()
@@ -71,13 +86,21 @@ async fn test_ordered_concurrent_get_foreach() {
         .await
         .collect();
 
-    assert_eq!(results,
+    assert_eq!(
+        results,
         vec![
-            ( 106, "https://evemaps.dotlan.net/route/3:Amarr:Jita:Dodixie:Hek:Rens:Nisuwa".to_string() ),
-            (  66, "https://evemaps.dotlan.net/route/3:Jita:Dodixie:Hek:Rens:Nisuwa"      .to_string() ),
-            (  86, "https://evemaps.dotlan.net/route/3:Amarr:Dodixie:Hek:Rens:Nisuwa"     .to_string() ),
-            (  79, "https://evemaps.dotlan.net/route/3:Amarr:Jita:Hek:Rens:Nisuwa"        .to_string() ),
-            (  98, "https://evemaps.dotlan.net/route/3:Amarr:Jita:Dodixie:Rens:Nisuwa"    .to_string() ),
+            (106, "https://evemaps.dotlan.net/route/3:Amarr:Jita:Dodixie:Hek:Rens:Nisuwa"      .to_string() ),
+            (66 , "https://evemaps.dotlan.net/route/3:Jita:Dodixie:Hek:Rens:Nisuwa"            .to_string() ),
+            (86 , "https://evemaps.dotlan.net/route/3:Amarr:Dodixie:Hek:Rens:Nisuwa"           .to_string() ),
+            (79 , "https://evemaps.dotlan.net/route/3:Amarr:Jita:Hek:Rens:Nisuwa"              .to_string() ),
+            (98 , "https://evemaps.dotlan.net/route/3:Amarr:Jita:Dodixie:Rens:Nisuwa"          .to_string() ),
+
+            (20 , "https://evemaps.dotlan.net/route/3:Covryn:Brarel:Frarie:Renarelle:Vivanier" .to_string() ),
+            (19 , "https://evemaps.dotlan.net/route/3:Covryn:Brarel:Frarie:Renarelle:Nisuwa"   .to_string() ),
+            (29 , "https://evemaps.dotlan.net/route/3:Covryn:Brarel:Frarie:Vivanier:Nisuwa"    .to_string() ),
+            (33 , "https://evemaps.dotlan.net/route/3:Covryn:Brarel:Renarelle:Vivanier:Nisuwa" .to_string() ),
+            (29 , "https://evemaps.dotlan.net/route/3:Covryn:Frarie:Renarelle:Vivanier:Nisuwa" .to_string() ),
+            (27 , "https://evemaps.dotlan.net/route/3:Brarel:Frarie:Renarelle:Vivanier:Nisuwa" .to_string() ),
         ]
     );
 }

--- a/src/tests/unordered.rs
+++ b/src/tests/unordered.rs
@@ -10,14 +10,21 @@ use crate::unordered::{
 
 use itertools::Itertools;
 
-const TO_FETCH: &[&str; 5] = &[
+const TO_FETCH: &[&str; 11] = &[
     "Amarr:Jita:Dodixie:Hek:Rens:Nisuwa",
     "Jita:Dodixie:Hek:Rens:Nisuwa",
     "Amarr:Dodixie:Hek:Rens:Nisuwa",
     "Amarr:Jita:Hek:Rens:Nisuwa",
     "Amarr:Jita:Dodixie:Rens:Nisuwa",
+
+    "Covryn:Brarel:Frarie:Renarelle:Vivanier",
+    "Covryn:Brarel:Frarie:Renarelle:Nisuwa",
+    "Covryn:Brarel:Frarie:Vivanier:Nisuwa",
+    "Covryn:Brarel:Renarelle:Vivanier:Nisuwa",
+    "Covryn:Frarie:Renarelle:Vivanier:Nisuwa",
+    "Brarel:Frarie:Renarelle:Vivanier:Nisuwa",
 ];
-const CONCURRENT: usize = 3;
+const CONCURRENT: usize = 2;
 
 
 
@@ -41,13 +48,20 @@ async fn test_unordered_concurrent_get() {
         .sorted()
         .collect();
 
-    assert_eq!(results,
+    assert_eq!(
+        results,
         vec![
-            (  66, "https://evemaps.dotlan.net/route/3:Jita:Dodixie:Hek:Rens:Nisuwa"      .to_string() ),
-            (  79, "https://evemaps.dotlan.net/route/3:Amarr:Jita:Hek:Rens:Nisuwa"        .to_string() ),
-            (  86, "https://evemaps.dotlan.net/route/3:Amarr:Dodixie:Hek:Rens:Nisuwa"     .to_string() ),
-            (  98, "https://evemaps.dotlan.net/route/3:Amarr:Jita:Dodixie:Rens:Nisuwa"    .to_string() ),
-            ( 106, "https://evemaps.dotlan.net/route/3:Amarr:Jita:Dodixie:Hek:Rens:Nisuwa".to_string() ),
+            (19 , "https://evemaps.dotlan.net/route/3:Covryn:Brarel:Frarie:Renarelle:Nisuwa"   .to_string() ),
+            (20 , "https://evemaps.dotlan.net/route/3:Covryn:Brarel:Frarie:Renarelle:Vivanier" .to_string() ),
+            (27 , "https://evemaps.dotlan.net/route/3:Brarel:Frarie:Renarelle:Vivanier:Nisuwa" .to_string() ),
+            (29 , "https://evemaps.dotlan.net/route/3:Covryn:Brarel:Frarie:Vivanier:Nisuwa"    .to_string() ),
+            (29 , "https://evemaps.dotlan.net/route/3:Covryn:Frarie:Renarelle:Vivanier:Nisuwa" .to_string() ),
+            (33 , "https://evemaps.dotlan.net/route/3:Covryn:Brarel:Renarelle:Vivanier:Nisuwa" .to_string() ),
+            (66 , "https://evemaps.dotlan.net/route/3:Jita:Dodixie:Hek:Rens:Nisuwa"            .to_string() ),
+            (79 , "https://evemaps.dotlan.net/route/3:Amarr:Jita:Hek:Rens:Nisuwa"              .to_string() ),
+            (86 , "https://evemaps.dotlan.net/route/3:Amarr:Dodixie:Hek:Rens:Nisuwa"           .to_string() ),
+            (98 , "https://evemaps.dotlan.net/route/3:Amarr:Jita:Dodixie:Rens:Nisuwa"          .to_string() ),
+            (106, "https://evemaps.dotlan.net/route/3:Amarr:Jita:Dodixie:Hek:Rens:Nisuwa"      .to_string() ),
         ]
     );
 }
@@ -75,13 +89,20 @@ async fn test_unordered_concurrent_get_foreach() {
         .sorted()
         .collect();
 
-    assert_eq!(results,
+    assert_eq!(
+        results,
         vec![
-            (  66, "https://evemaps.dotlan.net/route/3:Jita:Dodixie:Hek:Rens:Nisuwa"      .to_string() ),
-            (  79, "https://evemaps.dotlan.net/route/3:Amarr:Jita:Hek:Rens:Nisuwa"        .to_string() ),
-            (  86, "https://evemaps.dotlan.net/route/3:Amarr:Dodixie:Hek:Rens:Nisuwa"     .to_string() ),
-            (  98, "https://evemaps.dotlan.net/route/3:Amarr:Jita:Dodixie:Rens:Nisuwa"    .to_string() ),
-            ( 106, "https://evemaps.dotlan.net/route/3:Amarr:Jita:Dodixie:Hek:Rens:Nisuwa".to_string() ),
+            (19 , "https://evemaps.dotlan.net/route/3:Covryn:Brarel:Frarie:Renarelle:Nisuwa"   .to_string() ),
+            (20 , "https://evemaps.dotlan.net/route/3:Covryn:Brarel:Frarie:Renarelle:Vivanier" .to_string() ),
+            (27 , "https://evemaps.dotlan.net/route/3:Brarel:Frarie:Renarelle:Vivanier:Nisuwa" .to_string() ),
+            (29 , "https://evemaps.dotlan.net/route/3:Covryn:Brarel:Frarie:Vivanier:Nisuwa"    .to_string() ),
+            (29 , "https://evemaps.dotlan.net/route/3:Covryn:Frarie:Renarelle:Vivanier:Nisuwa" .to_string() ),
+            (33 , "https://evemaps.dotlan.net/route/3:Covryn:Brarel:Renarelle:Vivanier:Nisuwa" .to_string() ),
+            (66 , "https://evemaps.dotlan.net/route/3:Jita:Dodixie:Hek:Rens:Nisuwa"            .to_string() ),
+            (79 , "https://evemaps.dotlan.net/route/3:Amarr:Jita:Hek:Rens:Nisuwa"              .to_string() ),
+            (86 , "https://evemaps.dotlan.net/route/3:Amarr:Dodixie:Hek:Rens:Nisuwa"           .to_string() ),
+            (98 , "https://evemaps.dotlan.net/route/3:Amarr:Jita:Dodixie:Rens:Nisuwa"          .to_string() ),
+            (106, "https://evemaps.dotlan.net/route/3:Amarr:Jita:Dodixie:Hek:Rens:Nisuwa"      .to_string() ),
         ]
     );
 }

--- a/src/unordered/get_foreach.rs
+++ b/src/unordered/get_foreach.rs
@@ -7,7 +7,9 @@ use std::sync::mpsc::{
     channel,
 };
 
-use crate::config;
+use crate::{
+    client,
+};
 
 
 
@@ -17,10 +19,7 @@ where
     I: IntoIterator<Item=S>,
     F: Copy + FnOnce(reqwest::Result<Response>) -> R,
 {
-    let client: Arc<Client> = Arc::new(Client::builder()
-        .user_agent(config::USER_AGENT)
-        .build()
-        .unwrap());
+    let client: Arc<Client> = Arc::new(client::build_preset());
 
     let (sender, receiver) = channel();
 
@@ -44,5 +43,6 @@ where
         })
         .await;
 
+    drop(sender);
     receiver.into_iter()
 }


### PR DESCRIPTION
FIX: `mpsc` receiver requires all `Sender` to be dropped, otherwise led to receiver blocked forever, which was happening in v0.3.0